### PR TITLE
avoid nullpointer excception when a file does not contain a class

### DIFF
--- a/src/org/atoum/intellij/plugin/atoum/AtoumIconProvider.java
+++ b/src/org/atoum/intellij/plugin/atoum/AtoumIconProvider.java
@@ -6,13 +6,16 @@ import com.intellij.openapi.util.Iconable.IconFlags;
 import com.intellij.psi.PsiElement;
 import com.jetbrains.php.lang.psi.PhpFile;
 import javax.swing.Icon;
+
+import com.jetbrains.php.lang.psi.elements.PhpClass;
 import org.jetbrains.annotations.NotNull;
 
 public class AtoumIconProvider extends IconProvider {
 
     public Icon getIcon(@NotNull PsiElement element, @IconFlags int flags) {
         if (element instanceof PhpFile) {
-            if (Utils.isClassAtoumTest(Utils.getFirstClassFromFile((PhpFile) element))) {
+            PhpClass firstClass = Utils.getFirstClassFromFile((PhpFile) element);
+            if (firstClass != null && Utils.isClassAtoumTest(firstClass)) {
                 return Icons.ATOUM_FILE;
             }
         }


### PR DESCRIPTION
Check if there is a first class in the file before validate if it's
a test class.

fixes #46