### PR TITLE
remove "empty test suite" message in console when test passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `dev-master`
 
+## Bugfix
+
+* [#53](https://github.com/atoum/phpstorm-plugin/pull/53) Remove "empty test suite" message in console when test passes ([@agallou])
 
 
 # 0.5.2 - 2016-02-03

--- a/src/org/atoum/intellij/plugin/atoum/run/SMTRootTestProxyFactory.java
+++ b/src/org/atoum/intellij/plugin/atoum/run/SMTRootTestProxyFactory.java
@@ -17,7 +17,7 @@ public class SMTRootTestProxyFactory {
         }
 
         for (MethodResult methodsResult: classResult.getMethods()) {
-            SMTestProxy methodNode = new SMTestProxy(methodsResult.getName(), true, "");
+            SMTestProxy methodNode = new SMTestProxy(methodsResult.getName(), false, "");
 
             if (methodsResult.getState().equals(MethodResult.STATE_FAILED)) {
                 methodNode.setTestFailed(methodsResult.getName() + " Failed", methodsResult.getContent(), true);


### PR DESCRIPTION
When the test passed a message "empty test suite" were displayed.
That's not the case anymore.

fixes #52 

before : 
![capture du 2016-02-06 20 51 42](https://cloud.githubusercontent.com/assets/320372/12869055/c8a9e020-cd14-11e5-9c0a-b8314be49d21.png)

after : 
![capture du 2016-02-06 20 50 59](https://cloud.githubusercontent.com/assets/320372/12869061/ed6a9ae4-cd14-11e5-9660-88a0e544b2ce.png)

