### PR TITLE
Tests could now be runned on an entry on the right-clic menu of the open file tabs

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -49,6 +49,7 @@
     <action id="AtoumRunTests" class="org.atoum.intellij.plugin.atoum.actions.Run"
             icon="/org/atoum/intellij/plugin/atoum/icons/atoum_16_16.png"
             text="run tests">
+      <add-to-group group-id="EditorTabPopupMenu"/>
       <add-to-group group-id="RunMenu" anchor="last"/>
       <add-to-group group-id="EditorPopupMenu.Run" anchor="last"/>
       <keyboard-shortcut first-keystroke="alt shift M" keymap="$default"/>


### PR DESCRIPTION
![capture du 2016-02-07 18 47 03](https://cloud.githubusercontent.com/assets/320372/12873992/6cb87972-cdcb-11e5-8964-8175fdb36287.png)
