### PR TITLE
display an error message when tests could not be run

### DIFF
--- a/src/org/atoum/intellij/plugin/atoum/run/Runner.java
+++ b/src/org/atoum/intellij/plugin/atoum/run/Runner.java
@@ -17,6 +17,9 @@ import com.intellij.execution.testframework.sm.runner.SMTestProxy;
 import com.intellij.execution.testframework.sm.runner.ui.SMTRunnerConsoleView;
 import com.intellij.execution.testframework.sm.runner.ui.TestResultsViewer;
 import com.intellij.execution.testframework.ui.BaseTestsOutputConsoleView;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.Key;
@@ -167,6 +170,7 @@ public class Runner {
 
 
         } catch (ExecutionException e) {
+            Notifications.Bus.notify(new Notification("atoumGroup", "Error running tests", e.getMessage(), NotificationType.ERROR, null), project);
         }
 
         return testsOutputConsoleView;


### PR DESCRIPTION
fixes #51 

display a message like this:
![capture du 2016-02-07 18 57 49](https://cloud.githubusercontent.com/assets/320372/12874694/e9c63dde-cdd8-11e5-9971-62559d9ba299.png)
