### PR TITLE
fix navigation to test class when the tested class is in the global namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `dev-master`
 
+## Bugfix
+
+* [#60](https://github.com/atoum/phpstorm-plugin/pull/60) Fix navigation to test class when the tested class is in the global namespace ([@agallou])
 
 
 # 0.6.0 - 2016-02-07

--- a/src/org/atoum/intellij/plugin/atoum/Utils.java
+++ b/src/org/atoum/intellij/plugin/atoum/Utils.java
@@ -32,6 +32,13 @@ public class Utils {
 
     @Nullable
     public static Collection<PhpClass> locateTestClasses(Project project, PhpClass testedClass) {
+        if (testedClass.getNamespaceName().length() == 1) {
+            Collection<PhpClass> foundClasses = locatePhpClasses(project, getTestsNamespaceSuffix() + testedClass.getName());
+            if (foundClasses.size() > 0) {
+                return foundClasses;
+            }
+        }
+
         String[] namespaceParts = testedClass.getNamespaceName().split("\\\\");
 
         for(int i=namespaceParts.length; i>=1; i--){


### PR DESCRIPTION
fixes #59