### PR TITLE
fix error displaying the test result when fatal error in test

### DIFF
--- a/src/org/atoum/intellij/plugin/atoum/model/TestsResultFactory.java
+++ b/src/org/atoum/intellij/plugin/atoum/model/TestsResultFactory.java
@@ -11,7 +11,7 @@ public class TestsResultFactory {
         TestsResult testsResult = new TestsResult();
 
         Pattern statusLinePattern = Pattern.compile("((?:not )?ok) (\\d+)(?: (?:# SKIP|# TODO|-) (.+)::(.+)\\(\\))?$");
-        Pattern nameLinePattern = Pattern.compile("^# (.+)::(.+)\\(\\)$");
+        Pattern nameLinePattern = Pattern.compile("^# ([\\w\\\\]+)::(.+)\\(\\)$");
 
         String[] tapOutputLines = tapOutput.split("\n");
 


### PR DESCRIPTION
fixes #61 : when a fatal error appears in test the fatal where show as a class in the test resuts.

For exemple.

```
 not ok 1 - mageekguy\atoum\blackfire\asserters\tests\units\blackfire::testAll()
 # Fatal error : Call to undefined method Blackfire\Profile::getUrl()
 # /home/agallou/Projets/blackfire-extension/tests/units/classes/asserters/blackfire.php
```

A test method geturl and a test class Blackfire\Profile where displayed.

@jubianchi there may be the same issue with the atoum plugin