### PR TITLE
display tests list when all tests are passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `dev-master`
 
+## Features
+
+* [#63](https://github.com/atoum/phpstorm-plugin/pull/63) Display tests list when all tests are passed ([@agallou])
+
 ## Bugfix
 
 * [#62](https://github.com/atoum/phpstorm-plugin/pull/62) Fix test class method list when the test has a fatal error in test ([@agallou])

--- a/src/org/atoum/intellij/plugin/atoum/run/Runner.java
+++ b/src/org/atoum/intellij/plugin/atoum/run/Runner.java
@@ -83,7 +83,7 @@ public class Runner {
         Executor executor = DefaultRunExecutor.getRunExecutorInstance();
         PhpRunConfiguration runConfiguration = new AtoumLocalRunConfiguration(project, myFactory, "test");
         TestConsoleProperties testConsoleProperties = new SMTRunnerConsoleProperties(runConfiguration, "atoum", executor);
-        BaseTestsOutputConsoleView testsOutputConsoleView = SMTestRunnerConnectionUtil.createConsole("atoumConsole", testConsoleProperties);
+        final BaseTestsOutputConsoleView testsOutputConsoleView = SMTestRunnerConnectionUtil.createConsole("atoumConsole", testConsoleProperties);
 
         Disposer.register(project, testsOutputConsoleView);
 
@@ -147,6 +147,10 @@ public class Runner {
                     SMTRootTestProxyFactory.updateFromTestResult(testsResult, testsRootNode);
 
                     selectFirstFailedMethod();
+
+                    if (testsResult.getState().equals(testsResult.STATE_PASSED)) {
+                        TestConsoleProperties.HIDE_PASSED_TESTS.set(testsOutputConsoleView.getProperties(), false);
+                    }
                 }
 
                 protected void selectFirstFailedMethod()


### PR DESCRIPTION
Even when all tests passed, the button to display passed tests
where not pressed : that's now the case.

So, now :
* when there is one or more error, only failed tests are displayed (the user must
click on a button to also display passed tests)
* when there is no error, all passed tests are displayed.