### PR TITLE
fix tap parsing in version 0.0.1 of atoum

### DIFF
--- a/src/org/atoum/intellij/plugin/atoum/model/TestsResultFactory.java
+++ b/src/org/atoum/intellij/plugin/atoum/model/TestsResultFactory.java
@@ -12,6 +12,7 @@ public class TestsResultFactory {
 
         Pattern statusLinePattern = Pattern.compile("((?:not )?ok) (\\d+)(?: (?:# SKIP|# TODO|-) (.+)::(.+)\\(\\))?$");
         Pattern nameLinePattern = Pattern.compile("^# ([\\w\\\\]+)::(.+)\\(\\)$");
+        Pattern planLinePattern = Pattern.compile("^\\d+\\.\\.\\d+$");
 
         String[] tapOutputLines = tapOutput.split("\n");
 
@@ -21,9 +22,12 @@ public class TestsResultFactory {
         String currentClassname = "";
         String currentStatus = "";
 
-        //The first line contains the number of tests
-        for (Integer i = 1; i < tapOutputLines.length; i++) {
+        for (Integer i = 0; i < tapOutputLines.length; i++) {
             String currentLine = tapOutputLines[i];
+
+            if (i == 0 && planLinePattern.matcher(currentLine).matches()) {
+                continue;
+            }
 
             Matcher statusLineMatcher = statusLinePattern.matcher(currentLine);
 


### PR DESCRIPTION
In version 0.0.1 of atoum the plan line (1..1 for example) is not displayed (it's displayed in version 1.0.0 and after).

fixes #67 