### PR TITLE
add support for .atoum.phpstorm.php file

### DIFF
--- a/src/org/atoum/intellij/plugin/atoum/run/CommandLineArgumentsBuilder.java
+++ b/src/org/atoum/intellij/plugin/atoum/run/CommandLineArgumentsBuilder.java
@@ -20,6 +20,14 @@ public class CommandLineArgumentsBuilder {
         return this;
     }
 
+    public CommandLineArgumentsBuilder useConfigFile(String configFilePath)
+    {
+        this.commandLineArgs.add("-c");
+        this.commandLineArgs.add(configFilePath);
+
+        return this;
+    }
+
     public CommandLineArgumentsBuilder useConfiguration(RunnerConfiguration runnerConfiguration)
     {
         if (null != runnerConfiguration.getDirectory()) {

--- a/src/org/atoum/intellij/plugin/atoum/run/Runner.java
+++ b/src/org/atoum/intellij/plugin/atoum/run/Runner.java
@@ -37,6 +37,7 @@ import org.atoum.intellij.plugin.atoum.model.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.atoum.intellij.plugin.atoum.Icons;
+import java.io.File;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -87,8 +88,6 @@ public class Runner {
 
         Disposer.register(project, testsOutputConsoleView);
 
-        String[] commandLineArgs = (new CommandLineArgumentsBuilder()).useTapReport().useConfiguration(runnerConfiguration).build();
-
         VirtualFile testBaseDir = null;
         try {
             testBaseDir = AtoumUtils.findTestBaseDir(runnerConfiguration, project);
@@ -96,6 +95,17 @@ public class Runner {
             return testsOutputConsoleView;
         }
 
+        CommandLineArgumentsBuilder commandLineBuilder = (new CommandLineArgumentsBuilder())
+            .useTapReport()
+            .useConfiguration(runnerConfiguration)
+        ;
+
+        String phpstormConfigFile = testBaseDir.getPath() + "/.atoum.phpstorm.php";
+        if (new File(phpstormConfigFile).exists()) {
+            commandLineBuilder.useConfigFile(phpstormConfigFile);
+        }
+
+        String[] commandLineArgs = commandLineBuilder.build();
 
         ContentManager contentManager = toolWindow.getContentManager();
         Content myContent;


### PR DESCRIPTION
The plugin could now have a specific configuration file.

When the file .atoum.phpstorm.php exists on the tests root,
this config file is loaded.

Like that some configuration could be defined, for only when launching tests
from the IDE.

Example of configuration :
```
<?php

$script->setMaxChildrenNumber(1);
$script->disableCodeCoverage();
```

fixes #65 