### PR TITLE
Launch one method by right clicking on its body (not just its name)

### DIFF
--- a/src/org/atoum/intellij/plugin/atoum/actions/Run.java
+++ b/src/org/atoum/intellij/plugin/atoum/actions/Run.java
@@ -31,14 +31,14 @@ public class Run extends AnAction {
             event.getPresentation().setEnabled(true);
             Method currentTestMethod = getCurrentTestMethod(event);
             if (currentTestMethod != null) {
-                event.getPresentation().setText("atoum - run " + currentTestClass.getName() + "::" + currentTestMethod.getName());
+                event.getPresentation().setText("atoum - run " + currentTestClass.getName() + "::" + currentTestMethod.getName(), false);
             } else {
-                event.getPresentation().setText("atoum - run test : " + currentTestClass.getName());
+                event.getPresentation().setText("atoum - run test : " + currentTestClass.getName(), false);
             }
         } else {
             VirtualFile selectedDir = getCurrentTestDirectory(event);
             if (selectedDir != null) {
-                event.getPresentation().setText("atoum - run dir : " + selectedDir.getName());
+                event.getPresentation().setText("atoum - run dir : " + selectedDir.getName(), false);
                 event.getPresentation().setEnabled(true);
             }
         }

--- a/src/org/atoum/intellij/plugin/atoum/actions/SwitchContext.java
+++ b/src/org/atoum/intellij/plugin/atoum/actions/SwitchContext.java
@@ -21,7 +21,7 @@ public class SwitchContext extends AnAction {
             return;
         }
 
-        e.getPresentation().setText("atoum - switch to : " + testedClass.getFQN());
+        e.getPresentation().setText("atoum - switch to : " + testedClass.getFQN(), false);
         e.getPresentation().setEnabled(true);
     }
 

--- a/tests/org/atoum/intellij/plugin/atoum/tests/RunTest.java
+++ b/tests/org/atoum/intellij/plugin/atoum/tests/RunTest.java
@@ -1,0 +1,77 @@
+package org.atoum.intellij.plugin.atoum.tests;
+
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.editor.CaretModel;
+import com.intellij.testFramework.TestActionEvent;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.atoum.intellij.plugin.atoum.actions.Run;
+
+import java.io.File;
+
+public class RunTest extends LightCodeInsightFixtureTestCase {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        // Add Fixtures
+        myFixture.configureFromExistingVirtualFile(myFixture.copyFileToProject("TestWithMethods.php"));
+    }
+
+    protected String getTestDataPath() {
+        return new File(this.getClass().getResource("fixtures").getFile()).getAbsolutePath();
+    }
+
+    public void testGetCurrentTestMethod() {
+        Run action = new Run();
+        TestActionEvent e = new TestActionEvent(action);
+        CaretModel cursor = CommonDataKeys.EDITOR.getData(e.getDataContext()).getCaretModel();
+
+        // Ensure cursor is at position 0
+        cursor.moveToOffset(0);
+        action.update(e);
+        assertTrue(e.getPresentation().isEnabledAndVisible());
+        assertEquals("atoum - run test : TestWithMethods", e.getPresentation().getText());
+
+        // Move cursor on the class declaration
+        cursor.moveToOffset(190);
+        action.update(e);
+        assertTrue(e.getPresentation().isEnabledAndVisible());
+        assertEquals("atoum - run test : TestWithMethods", e.getPresentation().getText());
+
+        // Move cursor on method declaration: beforeTestMethod
+        cursor.moveToOffset(230);
+        action.update(e);
+        assertTrue(e.getPresentation().isEnabledAndVisible());
+        assertEquals("atoum - run test : TestWithMethods", e.getPresentation().getText());
+
+        // Move cursor in method body: beforeTestMethod
+        cursor.moveToOffset(345);
+        action.update(e);
+        assertTrue(e.getPresentation().isEnabledAndVisible());
+        assertEquals("atoum - run test : TestWithMethods", e.getPresentation().getText());
+
+        // Move cursor on method declaration: test__construct_bad
+        cursor.moveToOffset(420);
+        action.update(e);
+        assertTrue(e.getPresentation().isEnabledAndVisible());
+        assertEquals("atoum - run TestWithMethods::test__construct_bad", e.getPresentation().getText());
+
+        // Move cursor in method body: test__construct_bad
+        cursor.moveToOffset(580);
+        action.update(e);
+        assertTrue(e.getPresentation().isEnabledAndVisible());
+        assertEquals("atoum - run TestWithMethods::test__construct_bad", e.getPresentation().getText());
+
+        // Move cursor on method declaration: test__construct_ok
+        cursor.moveToOffset(740);
+        action.update(e);
+        assertTrue(e.getPresentation().isEnabledAndVisible());
+        assertEquals("atoum - run TestWithMethods::test__construct_ok", e.getPresentation().getText());
+
+        // Move cursor in method body: test__construct_ok
+        cursor.moveToOffset(815);
+        action.update(e);
+        assertTrue(e.getPresentation().isEnabledAndVisible());
+        assertEquals("atoum - run TestWithMethods::test__construct_ok", e.getPresentation().getText());
+    }
+}

--- a/tests/org/atoum/intellij/plugin/atoum/tests/fixtures/TestWithMethods.php
+++ b/tests/org/atoum/intellij/plugin/atoum/tests/fixtures/TestWithMethods.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace PhpStormPlugin\tests\units;
+
+use atoum;
+
+/**
+ * /!\ MODIFY THIS FILE WILL BREAK TEST IN RunTest.java BECAUSE IT RELY ON CARET POSITION IN THE FILE
+ */
+
+class TestWithMethods extends atoum
+{
+    public function beforeTestMethod($method)
+    {
+        if (defined('PHP_WINDOWS_VERSION_MAJOR') === false) {
+            $this->skip('Can only run on Windows');
+        }
+    }
+
+    public function test__construct_bad()
+    {
+        $this->assert
+            ->exception(function () {
+                new \Pickle\Engine\PHP("");
+            });
+
+        $this->assert
+            ->exception(function () {
+                new \Pickle\Engine\PHP("c:\\windows\\system32\\at.exe");
+            });
+    }
+
+    public function test__construct_ok()
+    {
+        $p = new \Pickle\Engine\PHP();
+
+        $this
+            ->object($p)
+                ->isInstanceOf('\Pickle\Engine\PHP');
+    }
+}


### PR DESCRIPTION
![atoum](https://user-images.githubusercontent.com/1501825/30939435-b19778b0-a3dd-11e7-811b-b84775dc842a.gif)

Same behavior as PhpUnit integration in PhpStorm.
We can run only one method by right clicking on its body. Until now, we can do this by right clicking on the method declaration line. It's now easier and similar to PhpUnit.

~Tests will be red until https://github.com/atoum/phpstorm-plugin/pull/82/commits/e352ac72ff53859fb86ddb858871af2b3386d08b is not merged. I will rebase this PR after merge.~