### PR TITLE
Fix test detection when tests extends atoum\test

### DIFF
--- a/src/org/atoum/intellij/plugin/atoum/Utils.java
+++ b/src/org/atoum/intellij/plugin/atoum/Utils.java
@@ -31,7 +31,7 @@ public class Utils {
         PhpClass loopCheckedClass = checkedClass;
         while (loopCheckedClass.getSuperClass() != null) {
             PhpClass parent = loopCheckedClass.getSuperClass();
-            if (parent.getFQN().equals("\\atoum")) {
+            if (parent.getFQN().equals("\\atoum") || parent.getFQN().equals("\\atoum\\test")) {
                 return true;
             }
             loopCheckedClass = parent;
@@ -42,7 +42,7 @@ public class Utils {
             List<ClassReference> extendsList = checkedClass.getExtendsList().getReferenceElements();
             if (extendsList.iterator().hasNext()) {
                 ClassReference ref = extendsList.iterator().next();
-                if (ref.getFQN() != null && ref.getFQN().equals("\\atoum")) {
+                if (ref.getFQN() != null && (ref.getFQN().equals("\\atoum") || ref.getFQN().equals("\\atoum\\test"))) {
                     return true;
                 }
             }

--- a/tests/org/atoum/intellij/plugin/atoum/tests/UtilsTest.java
+++ b/tests/org/atoum/intellij/plugin/atoum/tests/UtilsTest.java
@@ -37,6 +37,12 @@ public class UtilsTest extends LightCodeInsightFixtureTestCase {
         assertEquals("\\PhpStormPlugin\\tests\\units\\TestSimpleClass", phpClass.getFQN());
 
         phpClass = Utils.getFirstTestClassFromFile((PhpFile) myFixture.configureByFile(
+                "TestSimpleClass2.php"
+        ));
+        assertNotNull(phpClass);
+        assertEquals("\\PhpStormPlugin\\tests\\units\\TestSimpleClass2", phpClass.getFQN());
+
+        phpClass = Utils.getFirstTestClassFromFile((PhpFile) myFixture.configureByFile(
             "TestMultipleClassNotFirst.php"
         ));
         assertNotNull(phpClass);
@@ -47,6 +53,12 @@ public class UtilsTest extends LightCodeInsightFixtureTestCase {
         ));
         assertNotNull(phpClass);
         assertEquals("\\PhpStormPlugin\\tests\\units\\TestSimpleClassWithoutUse", phpClass.getFQN());
+
+        phpClass = Utils.getFirstTestClassFromFile((PhpFile) myFixture.configureByFile(
+                "TestSimpleClassWithoutUse2.php"
+        ));
+        assertNotNull(phpClass);
+        assertEquals("\\PhpStormPlugin\\tests\\units\\TestSimpleClassWithoutUse2", phpClass.getFQN());
 
         phpClass = Utils.getFirstTestClassFromFile((PhpFile) myFixture.configureByFile(
             "TestWithParentClass.php"
@@ -73,6 +85,12 @@ public class UtilsTest extends LightCodeInsightFixtureTestCase {
         assertEquals("\\PhpStormPlugin\\tests\\units\\TestSimpleClass", phpClass.getFQN());
 
         phpClass = Utils.getFirstTestClassFromFile((PhpFile) myFixture.configureByFile(
+                "TestSimpleClass2.php"
+        ));
+        assertNotNull(phpClass);
+        assertEquals("\\PhpStormPlugin\\tests\\units\\TestSimpleClass2", phpClass.getFQN());
+
+        phpClass = Utils.getFirstTestClassFromFile((PhpFile) myFixture.configureByFile(
                 "TestMultipleClassNotFirst.php"
         ));
         assertNotNull(phpClass);
@@ -83,6 +101,12 @@ public class UtilsTest extends LightCodeInsightFixtureTestCase {
         ));
         assertNotNull(phpClass);
         assertEquals("\\PhpStormPlugin\\tests\\units\\TestSimpleClassWithoutUse", phpClass.getFQN());
+
+        phpClass = Utils.getFirstTestClassFromFile((PhpFile) myFixture.configureByFile(
+                "TestSimpleClassWithoutUse2.php"
+        ));
+        assertNotNull(phpClass);
+        assertEquals("\\PhpStormPlugin\\tests\\units\\TestSimpleClassWithoutUse2", phpClass.getFQN());
 
         phpClass = Utils.getFirstTestClassFromFile((PhpFile) myFixture.configureByFile(
                 "TestWithParentClass.php"

--- a/tests/org/atoum/intellij/plugin/atoum/tests/fixtures/TestSimpleClass2.php
+++ b/tests/org/atoum/intellij/plugin/atoum/tests/fixtures/TestSimpleClass2.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PhpStormPlugin\tests\units;
+
+use \atoum\test;
+
+class TestSimpleClass2 extends test
+{
+
+}

--- a/tests/org/atoum/intellij/plugin/atoum/tests/fixtures/TestSimpleClassWithoutUse2.php
+++ b/tests/org/atoum/intellij/plugin/atoum/tests/fixtures/TestSimpleClassWithoutUse2.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PhpStormPlugin\tests\units;
+
+class TestSimpleClassWithoutUse2 extends \atoum\test
+{
+
+}

--- a/tests/org/atoum/intellij/plugin/atoum/tests/fixtures/atoum.php
+++ b/tests/org/atoum/intellij/plugin/atoum/tests/fixtures/atoum.php
@@ -1,6 +1,13 @@
 <?php
 
-class atoum
+namespace atoum
+{
+    class test
+    {
+    }
+}
+
+class atoum extends atoum\test
 {
 
 }

--- a/travis.sh
+++ b/travis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-ideaVersion="2017.1.5"
-ideaPluginVersion="2017.1"
+ideaVersion="2018.2.4"
+ideaPluginVersion="182.4505.42"
 
 travisCache=".cache"
 
@@ -49,8 +49,8 @@ if [ -d ./plugins ]; then
     echo "created plugin dir"
 fi
 
-download "http://phpstorm.espend.de/files/proxy/phpstorm-${ideaPluginVersion}-php.zip"
-unzip -qo $travisCache/phpstorm-${ideaPluginVersion}-php.zip -d ./plugins
+download "https://plugins.jetbrains.com/files/6610/50359/php-${ideaPluginVersion}.zip"
+unzip -qo $travisCache/php-${ideaPluginVersion}.zip -d ./plugins
 
 # Run the tests
 if [ "$1" = "-d" ]; then


### PR DESCRIPTION
Tests should extends \atoum (cf doc) but you can also extends \atoum\test and it was not supported since #82